### PR TITLE
Add jdk 9 and 10 checks to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,9 @@ notifications:
 branches:
   only:
   - master
+jdk:
+  - oraclejdk10
+  - oraclejdk9
+  - openjdk9
+  - openjdk10
+


### PR DESCRIPTION
I didn't change the `pom.xml` for this one because I figured spring would be handled a bit differently than Java EE.
